### PR TITLE
Fix/output ids instead of names

### DIFF
--- a/menu/menu.js
+++ b/menu/menu.js
@@ -9,15 +9,19 @@ function onOpen() {
   // re:lationメニュー（全自治体対応）
   ui.createMenu('🟩 re:lation')
     .addItem('🎫 未対応チケット取得', 'fetchOpenTickets')
+    .addSeparator()
     .addItem('📋 詳細ページで表示', 'openTicketDetailPage')
     .addSeparator()
-    .addItem('🔔slack手動送信', 'manualSendSlack')
     .addToUi();
 
   ui.createMenu('🏛 設定')
     .addItem('📮 受信箱取得', 'fetchMessageBoxes')
     .addItem('🗂️ チケット分類取得', 'fetchCaseCategories')
     .addItem('🏷️ ラベル取得', 'fetchLabels')
+    .addToUi();
+
+  ui.createMenu('🔔 Slack')
+    .addItem('📤 Slack手動送信', 'manualSendSlack')
     .addSeparator()
     .addItem('🔧 Slackフィルタ設定', 'showFilterConfigDialog')
     .addToUi();

--- a/menu/menu.js
+++ b/menu/menu.js
@@ -10,19 +10,19 @@ function onOpen() {
   ui.createMenu('🟩 re:lation')
     .addItem('🎫 未対応チケット取得', 'fetchOpenTickets')
     .addSeparator()
-    .addItem('📋 詳細ページで表示', 'openTicketDetailPage')
-    .addSeparator()
-    .addToUi();
-
-  ui.createMenu('🏛 設定')
     .addItem('📮 受信箱取得', 'fetchMessageBoxes')
     .addItem('🗂️ チケット分類取得', 'fetchCaseCategories')
     .addItem('🏷️ ラベル取得', 'fetchLabels')
     .addToUi();
 
-  ui.createMenu('🔔 Slack')
+   ui.createMenu('🔔 Slack')
     .addItem('📤 Slack手動送信', 'manualSendSlack')
     .addSeparator()
     .addItem('🔧 Slackフィルタ設定', 'showFilterConfigDialog')
+    .addSeparator()
+    .addToUi();
+
+ ui.createMenu('🔍 tool')
+    .addItem('📋 チケット詳細確認', 'openTicketDetailPage')
     .addToUi();
 }

--- a/relation/fetchTickets.js
+++ b/relation/fetchTickets.js
@@ -86,11 +86,7 @@ function fetchOpenTickets() {
       
       var tickets = JSON.parse(response.getContentText());
       
-      // チケット分類とラベルの名前を取得
-      var caseCategoriesMap = getCaseCategoriesMap(config.messageBoxId);
-      var labelsMap = getLabelsMap(config.messageBoxId);
-      
-      console.log('自治体: ' + config.name + ', チケット分類数: ' + Object.keys(caseCategoriesMap).length + ', ラベル数: ' + Object.keys(labelsMap).length);
+      console.log('自治体: ' + config.name + ', チケット数: ' + tickets.length);
       
       // デバッグ用：最初のチケットの全プロパティを出力（APIレスポンス確認用）
       if (tickets.length > 0) {
@@ -110,14 +106,6 @@ function fetchOpenTickets() {
           console.log('チケットID: ' + ticket.ticket_id + ', ラベルID: ' + JSON.stringify(labelIds));
         }
         
-        var categoryNames = getCategoryNames(caseCategoryIds, caseCategoriesMap);
-        var labelNames = getLabelNames(labelIds, labelsMap);
-        
-        // デバッグ用ログ：ラベル名の変換結果をログ出力
-        if (labelIds.length > 0) {
-          console.log('ラベルID -> ラベル名変換: ' + JSON.stringify(labelIds) + ' -> ' + JSON.stringify(labelNames));
-        }
-        
         var ticketData = [
           config.messageBoxId,        // 受信箱ID
           config.name,                // 自治体名
@@ -127,8 +115,8 @@ function fetchOpenTickets() {
           ticket.assignee || '',      // 担当者のメンション名
           parseDate(ticket.created_at),          // 作成日（Dateオブジェクト）
           parseDate(ticket.last_updated_at),     // 更新日（Dateオブジェクト）
-          categoryNames.join(', '),   // チケット分類名
-          labelNames.join(', '),      // ラベル名
+          caseCategoryIds.join(', '), // チケット分類ID
+          labelIds.join(', '),        // ラベルID
           ticket.pending_reason_id || '',        // 保留理由ID
           ticket.color_cd || ''       // 色
         ];

--- a/relation/fetchTickets.js
+++ b/relation/fetchTickets.js
@@ -231,17 +231,6 @@ function fetchOpenTickets() {
 
 
 /**
- * ISO 8601形式の日時を読みやすい形式に変換
- * @param {string} isoString ISO 8601形式の日時文字列
- * @return {string} 読みやすい形式の日時 (yyyy/MM/dd HH:mm)
- */
-function formatDate(isoString) {
-  if (!isoString) return '';
-  var date = new Date(isoString);
-  return Utilities.formatDate(date, 'Asia/Tokyo', 'yyyy/MM/dd HH:mm');
-}
-
-/**
  * ISO 8601形式の日時をDateオブジェクトに変換
  * @param {string} isoString ISO 8601形式の日時文字列
  * @return {Date|string} Dateオブジェクトまたは空文字列

--- a/slack-filter/slack-filter-config.js
+++ b/slack-filter/slack-filter-config.js
@@ -321,22 +321,6 @@ function showFilterConfigHtmlDialog(messageBoxId, config) {
         <p><strong>受信箱ID:</strong> <?= messageBoxId ?></p>
         
         <div class="section">
-          <h3>🏷️ ラベルフィルタ</h3>
-          <div>
-            <strong>通知対象ラベル（チェックしたラベルのチケットのみ通知します）:</strong>
-            <div class="checkbox-group" id="includeLabels">
-              <? for (var labelId in labelsMap) { ?>
-                <div class="checkbox-item">
-                  <input type="checkbox" id="include_label_<?= labelId ?>" value="<?= labelId ?>" 
-                         <?= (currentFilter.include_label_ids && currentFilter.include_label_ids.includes(parseInt(labelId))) ? 'checked' : '' ?>>
-                  <label for="include_label_<?= labelId ?>"><?= labelId ?>: <?= labelsMap[labelId] ?></label>
-                </div>
-              <? } ?>
-            </div>
-          </div>
-        </div>
-        
-        <div class="section">
           <h3>🗂️ チケット分類フィルタ</h3>
           <div>
             <strong>通知対象分類（チェックした分類のチケットのみ通知します）:</strong>
@@ -346,6 +330,22 @@ function showFilterConfigHtmlDialog(messageBoxId, config) {
                   <input type="checkbox" id="include_category_<?= categoryId ?>" value="<?= categoryId ?>"
                          <?= (currentFilter.include_case_category_ids && currentFilter.include_case_category_ids.includes(parseInt(categoryId))) ? 'checked' : '' ?>>
                   <label for="include_category_<?= categoryId ?>"><?= categoryId ?>: <?= categoriesMap[categoryId] ?></label>
+                </div>
+              <? } ?>
+            </div>
+          </div>
+        </div>
+        
+        <div class="section">
+          <h3>🏷️ ラベルフィルタ</h3>
+          <div>
+            <strong>通知対象ラベル（チェックしたラベルのチケットのみ通知します）:</strong>
+            <div class="checkbox-group" id="includeLabels">
+              <? for (var labelId in labelsMap) { ?>
+                <div class="checkbox-item">
+                  <input type="checkbox" id="include_label_<?= labelId ?>" value="<?= labelId ?>" 
+                         <?= (currentFilter.include_label_ids && currentFilter.include_label_ids.includes(parseInt(labelId))) ? 'checked' : '' ?>>
+                  <label for="include_label_<?= labelId ?>"><?= labelId ?>: <?= labelsMap[labelId] ?></label>
                 </div>
               <? } ?>
             </div>
@@ -386,15 +386,6 @@ function showFilterConfigHtmlDialog(messageBoxId, config) {
           function buildConfigFromForm() {
             var config = {};
             
-            // 通知対象ラベル
-            var includeLabels = [];
-            document.querySelectorAll('#includeLabels input:checked').forEach(function(cb) {
-              includeLabels.push(parseInt(cb.value));
-            });
-            if (includeLabels.length > 0) {
-              config.include_label_ids = includeLabels;
-            }
-            
             // 通知対象分類
             var includeCategories = [];
             document.querySelectorAll('#includeCategories input:checked').forEach(function(cb) {
@@ -402,6 +393,15 @@ function showFilterConfigHtmlDialog(messageBoxId, config) {
             });
             if (includeCategories.length > 0) {
               config.include_case_category_ids = includeCategories;
+            }
+            
+            // 通知対象ラベル
+            var includeLabels = [];
+            document.querySelectorAll('#includeLabels input:checked').forEach(function(cb) {
+              includeLabels.push(parseInt(cb.value));
+            });
+            if (includeLabels.length > 0) {
+              config.include_label_ids = includeLabels;
             }
             
             return config;

--- a/slack-filter/slack-filter-config.js
+++ b/slack-filter/slack-filter-config.js
@@ -323,7 +323,7 @@ function showFilterConfigHtmlDialog(messageBoxId, config) {
         <div class="section">
           <h3>🏷️ ラベルフィルタ</h3>
           <div>
-            <strong>含むラベル（以下のラベルが付いているチケットのみ通知）:</strong>
+            <strong>通知対象ラベル（チェックしたラベルのチケットのみ通知します）:</strong>
             <div class="checkbox-group" id="includeLabels">
               <? for (var labelId in labelsMap) { ?>
                 <div class="checkbox-item">
@@ -334,44 +334,18 @@ function showFilterConfigHtmlDialog(messageBoxId, config) {
               <? } ?>
             </div>
           </div>
-          
-          <div style="margin-top: 15px;">
-            <strong>除外ラベル（以下のラベルが付いているチケットは通知しない）:</strong>
-            <div class="checkbox-group" id="excludeLabels">
-              <? for (var labelId in labelsMap) { ?>
-                <div class="checkbox-item">
-                  <input type="checkbox" id="exclude_label_<?= labelId ?>" value="<?= labelId ?>"
-                         <?= (currentFilter.exclude_label_ids && currentFilter.exclude_label_ids.includes(parseInt(labelId))) ? 'checked' : '' ?>>
-                  <label for="exclude_label_<?= labelId ?>"><?= labelId ?>: <?= labelsMap[labelId] ?></label>
-                </div>
-              <? } ?>
-            </div>
-          </div>
         </div>
         
         <div class="section">
           <h3>🗂️ チケット分類フィルタ</h3>
           <div>
-            <strong>含む分類（以下の分類のチケットのみ通知）:</strong>
+            <strong>通知対象分類（チェックした分類のチケットのみ通知します）:</strong>
             <div class="checkbox-group" id="includeCategories">
               <? for (var categoryId in categoriesMap) { ?>
                 <div class="checkbox-item">
                   <input type="checkbox" id="include_category_<?= categoryId ?>" value="<?= categoryId ?>"
                          <?= (currentFilter.include_case_category_ids && currentFilter.include_case_category_ids.includes(parseInt(categoryId))) ? 'checked' : '' ?>>
                   <label for="include_category_<?= categoryId ?>"><?= categoryId ?>: <?= categoriesMap[categoryId] ?></label>
-                </div>
-              <? } ?>
-            </div>
-          </div>
-          
-          <div style="margin-top: 15px;">
-            <strong>除外分類（以下の分類のチケットは通知しない）:</strong>
-            <div class="checkbox-group" id="excludeCategories">
-              <? for (var categoryId in categoriesMap) { ?>
-                <div class="checkbox-item">
-                  <input type="checkbox" id="exclude_category_<?= categoryId ?>" value="<?= categoryId ?>"
-                         <?= (currentFilter.exclude_case_category_ids && currentFilter.exclude_case_category_ids.includes(parseInt(categoryId))) ? 'checked' : '' ?>>
-                  <label for="exclude_category_<?= categoryId ?>"><?= categoryId ?>: <?= categoriesMap[categoryId] ?></label>
                 </div>
               <? } ?>
             </div>
@@ -412,7 +386,7 @@ function showFilterConfigHtmlDialog(messageBoxId, config) {
           function buildConfigFromForm() {
             var config = {};
             
-            // 含むラベル
+            // 通知対象ラベル
             var includeLabels = [];
             document.querySelectorAll('#includeLabels input:checked').forEach(function(cb) {
               includeLabels.push(parseInt(cb.value));
@@ -421,31 +395,13 @@ function showFilterConfigHtmlDialog(messageBoxId, config) {
               config.include_label_ids = includeLabels;
             }
             
-            // 除外ラベル
-            var excludeLabels = [];
-            document.querySelectorAll('#excludeLabels input:checked').forEach(function(cb) {
-              excludeLabels.push(parseInt(cb.value));
-            });
-            if (excludeLabels.length > 0) {
-              config.exclude_label_ids = excludeLabels;
-            }
-            
-            // 含む分類
+            // 通知対象分類
             var includeCategories = [];
             document.querySelectorAll('#includeCategories input:checked').forEach(function(cb) {
               includeCategories.push(parseInt(cb.value));
             });
             if (includeCategories.length > 0) {
               config.include_case_category_ids = includeCategories;
-            }
-            
-            // 除外分類
-            var excludeCategories = [];
-            document.querySelectorAll('#excludeCategories input:checked').forEach(function(cb) {
-              excludeCategories.push(parseInt(cb.value));
-            });
-            if (excludeCategories.length > 0) {
-              config.exclude_case_category_ids = excludeCategories;
             }
             
             return config;

--- a/slack-filter/slack-filter-config.js
+++ b/slack-filter/slack-filter-config.js
@@ -41,6 +41,7 @@ function showMunicipalitySelectionDialog(configs) {
             margin: 0 auto;
             background: white;
             padding: 30px;
+            padding-bottom: 100px;
             border-radius: 10px;
             box-shadow: 0 2px 10px rgba(0,0,0,0.1);
           }
@@ -98,8 +99,15 @@ function showMunicipalitySelectionDialog(configs) {
             margin-top: 4px;
           }
           .button-group {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: white;
+            border-top: 1px solid #ddd;
+            padding: 15px;
             text-align: center;
-            margin-top: 30px;
+            box-shadow: 0 -2px 10px rgba(0,0,0,0.1);
           }
           button {
             margin: 0 10px;
@@ -228,6 +236,11 @@ function showMunicipalitySelectionDialog(configs) {
               return;
             }
             
+            // ボタンを無効化して重複クリック防止
+            var selectButton = document.getElementById('selectButton');
+            selectButton.disabled = true;
+            selectButton.textContent = '🔄 設定画面を準備中...';
+            
             // サーバーサイド関数を呼び出してフィルタ設定画面を表示
             google.script.run
               .withSuccessHandler(function() {
@@ -235,6 +248,8 @@ function showMunicipalitySelectionDialog(configs) {
               })
               .withFailureHandler(function(error) {
                 alert('エラー: ' + error.toString());
+                selectButton.disabled = false;
+                selectButton.textContent = '✅ この自治体で設定する';
               })
               .showFilterConfigForMunicipality(selectedMunicipalityId);
           }
@@ -261,8 +276,8 @@ function showMunicipalitySelectionDialog(configs) {
   
   // HTMLダイアログを表示
   var htmlOutput = htmlTemplate.evaluate()
-    .setWidth(600)
-    .setHeight(500);
+    .setWidth(700)
+    .setHeight(600);
     
   SpreadsheetApp.getUi().showModalDialog(htmlOutput, '自治体選択 - Slackフィルタ設定');
 }
@@ -303,16 +318,24 @@ function showFilterConfigHtmlDialog(messageBoxId, config) {
       <head>
         <base target="_top">
         <style>
-          body { font-family: Arial, sans-serif; margin: 20px; }
+          body { font-family: Arial, sans-serif; margin: 20px; padding-bottom: 100px; }
           .section { margin-bottom: 20px; border: 1px solid #ddd; padding: 15px; border-radius: 5px; }
           .section h3 { margin-top: 0; color: #333; }
           .checkbox-group { max-height: 150px; overflow-y: auto; border: 1px solid #eee; padding: 10px; }
           .checkbox-item { margin: 5px 0; }
-          .button-group { text-align: center; margin-top: 20px; }
+          .button-group { position: fixed; bottom: 0; left: 0; right: 0; background: white; border-top: 1px solid #ddd; padding: 15px; text-align: center; box-shadow: 0 -2px 10px rgba(0,0,0,0.1); }
           button { margin: 0 10px; padding: 10px 20px; font-size: 14px; }
           .save-btn { background-color: #4CAF50; color: white; border: none; border-radius: 4px; }
+          .save-btn:disabled { background-color: #cccccc; cursor: not-allowed; }
           .cancel-btn { background-color: #f44336; color: white; border: none; border-radius: 4px; }
           .preview { background-color: #f9f9f9; border: 1px solid #ddd; padding: 10px; margin-top: 10px; font-family: monospace; white-space: pre-wrap; }
+          .notification { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); padding: 15px 25px; border-radius: 8px; font-size: 16px; font-weight: bold; z-index: 1000; box-shadow: 0 4px 12px rgba(0,0,0,0.15); }
+          .notification.success { background-color: #4CAF50; color: white; }
+          .notification.error { background-color: #f44336; color: white; }
+          .notification.show { animation: slideDown 0.3s ease-out; }
+          .notification.hide { animation: slideUp 0.3s ease-in; }
+          @keyframes slideDown { from { opacity: 0; transform: translateX(-50%) translateY(-20px); } to { opacity: 1; transform: translateX(-50%) translateY(0); } }
+          @keyframes slideUp { from { opacity: 1; transform: translateX(-50%) translateY(0); } to { opacity: 0; transform: translateX(-50%) translateY(-20px); } }
         </style>
       </head>
       <body>
@@ -407,17 +430,62 @@ function showFilterConfigHtmlDialog(messageBoxId, config) {
             return config;
           }
           
+          function showNotification(message, type, duration) {
+            duration = duration || 3000;
+            
+            // 既存の通知があれば削除
+            var existingNotification = document.querySelector('.notification');
+            if (existingNotification) {
+              existingNotification.remove();
+            }
+            
+            // 新しい通知を作成
+            var notification = document.createElement('div');
+            notification.className = 'notification ' + type;
+            notification.textContent = message;
+            
+            // ページに追加
+            document.body.appendChild(notification);
+            
+            // アニメーション表示
+            setTimeout(function() {
+              notification.classList.add('show');
+            }, 10);
+            
+            // 自動で非表示
+            setTimeout(function() {
+              notification.classList.add('hide');
+              setTimeout(function() {
+                if (notification.parentNode) {
+                  notification.parentNode.removeChild(notification);
+                }
+              }, 300);
+            }, duration);
+          }
+          
           function saveConfig() {
             var config = buildConfigFromForm();
+            
+            // 保存ボタンを無効化して状態変更
+            var saveButton = document.querySelector('.save-btn');
+            var originalText = saveButton.textContent;
+            saveButton.disabled = true;
+            saveButton.textContent = '🔄 設定を保存中...';
             
             // サーバーサイド関数を呼び出し
             google.script.run
               .withSuccessHandler(function() {
-                alert('フィルタ設定を保存しました');
-                google.script.host.close();
+                saveButton.textContent = '✅ 保存完了';
+                showNotification('✅ フィルタ設定を保存しました', 'success', 2000);
+                setTimeout(function() {
+                  google.script.host.close();
+                }, 2500);
               })
               .withFailureHandler(function(error) {
-                alert('保存エラー: ' + error.toString());
+                // エラー時はボタンを元に戻す
+                saveButton.disabled = false;
+                saveButton.textContent = originalText;
+                showNotification('❌ 保存エラー: ' + error.toString(), 'error', 5000);
               })
               .saveFilterConfig('<?= messageBoxId ?>', config);
           }
@@ -444,8 +512,8 @@ function showFilterConfigHtmlDialog(messageBoxId, config) {
   
   // HTMLダイアログを表示
   var htmlOutput = htmlTemplate.evaluate()
-    .setWidth(800)
-    .setHeight(600);
+    .setWidth(850)
+    .setHeight(700);
     
   SpreadsheetApp.getUi().showModalDialog(htmlOutput, 'Slackフィルタ設定 - ' + config.name);
 }

--- a/slack/README.md
+++ b/slack/README.md
@@ -75,7 +75,7 @@ sequenceDiagram
         alt Slackチャンネル設定あり
             FetchTickets->>Notifications: sendSlackToMunicipality(tickets, config, isLast)
             Notifications->>Notifications: applySlackNotificationFilter(tickets, config)
-            Note over Notifications: フィルタ条件適用<br/>- include_label_ids<br/>- exclude_label_ids<br/>- case_category_ids<br/>- priority_levels
+            Note over Notifications: フィルタ条件適用<br/>- include_label_ids<br/>- include_case_category_ids<br/>- priority_levels
             
             alt フィルタ条件該当チケットあり
                 Notifications->>Notifications: sendSlackWithRateLimit(tickets, config, isLast)

--- a/slack/data-fetcher.js
+++ b/slack/data-fetcher.js
@@ -45,9 +45,9 @@ function getTicketsFromSheet(messageBoxId) {
         var caseCategoryIdsStr = row[8] && row[8].toString().trim() ? row[8].toString() : '';
         var labelIdsStr = row[9] && row[9].toString().trim() ? row[9].toString() : '';
         
-        // IDを配列に変換
-        var caseCategoryIds = caseCategoryIdsStr ? caseCategoryIdsStr.split(', ').filter(function(id) { return id; }) : [];
-        var labelIds = labelIdsStr ? labelIdsStr.split(', ').filter(function(id) { return id; }) : [];
+        // IDを配列に変換（数値型に変換）
+        var caseCategoryIds = caseCategoryIdsStr ? caseCategoryIdsStr.split(', ').filter(function(id) { return id; }).map(function(id) { return parseInt(id, 10); }) : [];
+        var labelIds = labelIdsStr ? labelIdsStr.split(', ').filter(function(id) { return id; }).map(function(id) { return parseInt(id, 10); }) : [];
         
         // IDを名前に変換
         var caseCategoryNames = getCategoryNames(caseCategoryIds, caseCategoriesMap);

--- a/slack/notifications.js
+++ b/slack/notifications.js
@@ -241,28 +241,12 @@ function applySlackNotificationFilter(tickets, config) {
       if (!hasIncludeLabel) shouldNotify = false;
     }
     
-    // ラベルIDフィルタ（除く）
-    if (filterConditions.exclude_label_ids && filterConditions.exclude_label_ids.length > 0) {
-      var hasExcludeLabel = filterConditions.exclude_label_ids.some(function(labelId) {
-        return ticket.label_ids && ticket.label_ids.includes(labelId);
-      });
-      if (hasExcludeLabel) shouldNotify = false;
-    }
-    
     // チケット分類IDフィルタ（含む）
     if (filterConditions.include_case_category_ids && filterConditions.include_case_category_ids.length > 0) {
       var hasIncludeCategory = filterConditions.include_case_category_ids.some(function(categoryId) {
         return ticket.case_category_ids && ticket.case_category_ids.includes(categoryId);
       });
       if (!hasIncludeCategory) shouldNotify = false;
-    }
-    
-    // チケット分類IDフィルタ（除く）
-    if (filterConditions.exclude_case_category_ids && filterConditions.exclude_case_category_ids.length > 0) {
-      var hasExcludeCategory = filterConditions.exclude_case_category_ids.some(function(categoryId) {
-        return ticket.case_category_ids && ticket.case_category_ids.includes(categoryId);
-      });
-      if (hasExcludeCategory) shouldNotify = false;
     }
     
     // 優先度フィルタ

--- a/slack/notifications.js
+++ b/slack/notifications.js
@@ -225,19 +225,31 @@ function applySlackNotificationFilter(tickets, config) {
   // 設定シートからSlack通知フィルタ条件を取得
   var filterConditions = config.slackNotificationFilter;
   
+  console.log('=== フィルタ適用デバッグ ===');
+  console.log('自治体: ' + config.name);
+  console.log('フィルタ条件: ' + JSON.stringify(filterConditions));
+  console.log('入力チケット数: ' + tickets.length);
+  
   if (!filterConditions) {
     // フィルタ条件が設定されていない場合は全チケットを対象
+    console.log('フィルタ条件なし - 全チケット対象');
     return tickets;
   }
   
-  return tickets.filter(function(ticket) {
+  var filteredTickets = tickets.filter(function(ticket) {
     var shouldNotify = true;
+    
+    console.log('--- チケット検証 ---');
+    console.log('チケットID: ' + ticket.id);
+    console.log('チケット分類IDs: ' + JSON.stringify(ticket.case_category_ids));
+    console.log('ラベルIDs: ' + JSON.stringify(ticket.label_ids));
     
     // ラベルIDフィルタ（含む）
     if (filterConditions.include_label_ids && filterConditions.include_label_ids.length > 0) {
       var hasIncludeLabel = filterConditions.include_label_ids.some(function(labelId) {
         return ticket.label_ids && ticket.label_ids.includes(labelId);
       });
+      console.log('ラベルフィルタ結果: ' + hasIncludeLabel + ' (必要: ' + JSON.stringify(filterConditions.include_label_ids) + ')');
       if (!hasIncludeLabel) shouldNotify = false;
     }
     
@@ -246,16 +258,16 @@ function applySlackNotificationFilter(tickets, config) {
       var hasIncludeCategory = filterConditions.include_case_category_ids.some(function(categoryId) {
         return ticket.case_category_ids && ticket.case_category_ids.includes(categoryId);
       });
+      console.log('分類フィルタ結果: ' + hasIncludeCategory + ' (必要: ' + JSON.stringify(filterConditions.include_case_category_ids) + ')');
       if (!hasIncludeCategory) shouldNotify = false;
     }
     
-    // 優先度フィルタ
-    if (filterConditions.priority_levels && filterConditions.priority_levels.length > 0) {
-      if (!filterConditions.priority_levels.includes(ticket.priority_level)) {
-        shouldNotify = false;
-      }
-    }
-    
+    console.log('最終判定: ' + shouldNotify);
     return shouldNotify;
   });
+  
+  console.log('フィルタ後チケット数: ' + filteredTickets.length);
+  console.log('=========================');
+  
+  return filteredTickets;
 }

--- a/slack/sendUI/manualSend_css.html
+++ b/slack/sendUI/manualSend_css.html
@@ -2,6 +2,7 @@
   body { 
     font-family: Arial, sans-serif; 
     padding: 20px; 
+    padding-bottom: 100px;
     margin: 0;
   }
   .container {
@@ -51,7 +52,15 @@
     margin-top: 3px;
   }
   .buttons {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: white;
+    border-top: 1px solid #ddd;
+    padding: 15px;
     text-align: center;
+    box-shadow: 0 -2px 10px rgba(0,0,0,0.1);
   }
   .btn {
     padding: 10px 20px;

--- a/slack/sendUI/sendUI.js
+++ b/slack/sendUI/sendUI.js
@@ -34,10 +34,10 @@ function selectMunicipalityWithSearchableDialog(configs) {
     htmlTemplate.municipalityItemsHtml = municipalityItemsHtml;
     
     var htmlOutput = htmlTemplate.evaluate()
-      .setWidth(600)
-      .setHeight(500);
+      .setWidth(700)
+      .setHeight(600);
     
-    SpreadsheetApp.getUi().showModalDialog(htmlOutput, '自治体選択');
+    SpreadsheetApp.getUi().showModalDialog(htmlOutput, '受信箱選択');
     
     console.log('ダイアログ表示完了');
     

--- a/slack/sendUI/sendUI.js
+++ b/slack/sendUI/sendUI.js
@@ -133,40 +133,13 @@ function processSelectedMunicipality(municipalityCode) {
     console.log('チケット件数: ' + tickets.length);
     console.log('送信先: ' + selectedConfig.slackChannel);
     
-    var sendResult = sendSlack(tickets, selectedConfig);
+    // フィルタリングを適用した送信関数を使用
+    sendSlackToMunicipality(tickets, selectedConfig, true);
     
-    // 送信結果の処理（成功の場合はコンソールログのみ、エラーの場合のみダイアログ表示）
-    if (sendResult && sendResult.success) {
-      console.log('✅ 送信完了: 「' + selectedConfig.name + '」のopenチケット ' + tickets.length + '件を送信しました');
-      console.log('送信先: ' + selectedConfig.slackChannel);
-    } else {
-      // 送信失敗の場合のみダイアログを表示
-      var ui = SpreadsheetApp.getUi();
-      var errorMessage = '「' + selectedConfig.name + '」のSlack通知送信に失敗しました。\n\n';
-      errorMessage += '送信先: ' + selectedConfig.slackChannel + '\n';
-      
-      if (sendResult && sendResult.error) {
-        errorMessage += 'エラー詳細: ' + sendResult.error + '\n';
-        if (sendResult.errorResponse) {
-          errorMessage += 'Slack APIレスポンス: ' + JSON.stringify(sendResult.errorResponse) + '\n';
-        }
-      }
-      
-      errorMessage += '\n対処方法:\n';
-      errorMessage += '1) ボットがチャンネルに招待されているか確認\n';
-      errorMessage += '2) チャンネル名が正確か確認\n';
-      errorMessage += '3) Bot Tokenが有効か確認';
-      
-      ui.alert('送信失敗', errorMessage, ui.ButtonSet.OK);
-      
-      console.error('=== Slack送信失敗詳細 ===');
-      console.error('自治体: ' + selectedConfig.name);
-      console.error('送信先: ' + selectedConfig.slackChannel);
-      if (sendResult) {
-        console.error('エラー: ' + (sendResult.error || '不明'));
-        console.error('レスポンス: ' + JSON.stringify(sendResult.errorResponse || {}));
-      }
-    }
+    // 送信完了メッセージをコンソールに出力
+    // 送信完了メッセージをコンソールに出力
+    console.log('✅ フィルタリング付き送信完了: 「' + selectedConfig.name + '」のopenチケットを送信しました');
+    console.log('送信先: ' + selectedConfig.slackChannel);
     
   } catch (error) {
     console.error('自治体選択処理エラー: ' + error.toString());


### PR DESCRIPTION
**Slackフィルター設定＆UI改善**
ラベルとカテゴリの「除外」フィルターがなくなって、「含める」だけに統一されたよ。UIも分かりやすく整理されて、どのラベル・カテゴリで通知を受け取るかを選びやすくなってる。説明やレイアウトも見やすくなったし、ボタンの配置や通知も使いやすくなった。処理中はボタンが無効化されて、成功・失敗メッセージはアニメーション付きで表示されるようになった。（slack-filter/slack-filter-config.js で変更あり）

市町村選択やフィルター設定のダイアログサイズも大きくなって、見やすさ・使いやすさがアップ！(slack-filter/slack-filter-config.js)

**チケットデータ処理**
チケットデータはラベル・カテゴリの名前じゃなくてIDで保存するようになった。フィルター処理はIDでやって、表示の時だけ名前に変換するから、ロジックが一貫して分かりやすく・壊れにくくなったよ。（relation/fetchTickets.js, slack/data-fetcher.js）

日付フォーマットやラベル・カテゴリ名変換に関する使われてないコード・冗長なコードは削除されて、チケット取得処理がシンプルになった。（relation/fetchTickets.js）

**メニュー＆ドキュメント更新**
スプレッドシートのメニューも分かりやすく整理されて、Slack関連とチケット詳細ツールがそれぞれ独立したメニューになった。（menu/menu.js）

フィルターロジックのドキュメントも「除外」フィルターがなくなって「含める」だけになったこと、IDベースのフィルターになったことが反映されてる。（slack/README.md）